### PR TITLE
root.tk.call error fixed

### DIFF
--- a/pyjsonviewer/pyjsonviewer.py
+++ b/pyjsonviewer/pyjsonviewer.py
@@ -252,7 +252,7 @@ def main():
     root: Tk = tk.Tk()
     root.title('PyJSONViewer')
     root.geometry("500x500")
-    root.tk.call('wm', 'iconphoto', root.w,
+    root.tk.call('wm', 'iconphoto', root._w,
                  tk.PhotoImage(file=PROJECT_DIR + '/icon.py'))
     menubar = tk.Menu(root)
 


### PR DESCRIPTION
@line 255
WAS:
root.tk.call('wm', 'iconphoto', root.w, tk.PhotoImage(file=PROJECT_DIR + '/icon.py'))
IS:
root.tk.call('wm', 'iconphoto', root._w, tk.PhotoImage(file=PROJECT_DIR + '/icon.py'))