### PR TITLE
Added option to open files that do not end with ".json" (fixes #17)

### DIFF
--- a/pyjsonviewer/pyjsonviewer.py
+++ b/pyjsonviewer/pyjsonviewer.py
@@ -114,7 +114,7 @@ class JSONTreeFrame(ttk.Frame):
 
     def select_json_file(self):
         file_path = filedialog.askopenfilename(
-            initialdir=self.initial_dir, filetypes=[("JSON files", "*.json")])
+            initialdir=self.initial_dir, filetypes=[("JSON files", "*.json"),("All Files", "*.*")])
         self.set_table_data_from_json(file_path)
 
     def expand_all(self):
@@ -262,7 +262,7 @@ def main():
     if args.open:
         args.file = filedialog.askopenfilename(
             initialdir=args.dir,
-            filetypes=[("JSON files", "*.json")])
+            filetypes=[("JSON files", "*.json"),("All Files", "*.*")])
 
     app = JSONTreeFrame(root, json_path=args.file, initial_dir=args.dir)
 


### PR DESCRIPTION
This adds functionality to open files that are actually JSON but not saved as such, e.g. Chrome Bookmarks (as given in #17 by @LionKimbro) which are saved with no extension which previously couldn't be opened.

![allfiles](https://user-images.githubusercontent.com/55938505/115011230-063b5200-9ecc-11eb-9529-2bab6d7953fd.png)
