### PR TITLE
Added utf-8 encoding for viewing in Windows (fixes #16)

### DIFF
--- a/pyjsonviewer/pyjsonviewer.py
+++ b/pyjsonviewer/pyjsonviewer.py
@@ -228,7 +228,7 @@ class JSONTreeFrame(ttk.Frame):
 
     @staticmethod
     def load_json_data(file_path):
-        with open(file_path) as f:
+        with open(file_path, encoding = 'utf-8') as f:
             return json.load(f)
 
     @staticmethod


### PR DESCRIPTION
for the given example json file
```json
{
    "character_set_1": " 15.6” screen ",
    "Character_set_2": " स्वागतम "
}
```
it works fine in MacOS, 
![image](https://user-images.githubusercontent.com/55938505/115090261-053d0b80-9f32-11eb-85bb-8906ee02d0b9.png)

but in Windows, it gives an error
![image](https://user-images.githubusercontent.com/55938505/115090254-ff472a80-9f31-11eb-8299-696867e9c4cc.png)

adding UTF-8 encoding (as mentioned in #16 ) tends to fix that for us
![image](https://user-images.githubusercontent.com/55938505/115090431-78df1880-9f32-11eb-9e1a-14328c0c31ee.png)


