### PR TITLE
fix menu keyboard shortcuts.

### DIFF
--- a/pyjsonviewer/pyjsonviewer.py
+++ b/pyjsonviewer/pyjsonviewer.py
@@ -120,17 +120,20 @@ class JSONTreeFrame(ttk.Frame):
         if self.is_url(item_text):
             webbrowser.open(item_text)
 
-    def select_json_file(self):
+    def select_json_file(self, _):
+        #:param _: event arg (not used)
         file_path = filedialog.askopenfilename(
             initialdir=self.initial_dir,
             filetypes=FILETYPES)
         self.set_table_data_from_json(file_path)
 
-    def expand_all(self):
+    def expand_all(self, _):
+        #:param _: event arg (not used)
         for item in self.get_all_children(self.tree):
             self.tree.item(item, open=True)
 
-    def collapse_all(self):
+    def collapse_all(self, _):
+        #:param _: event arg (not used)
         for item in self.get_all_children(self.tree):
             self.tree.item(item, open=False)
 
@@ -165,7 +168,8 @@ class JSONTreeFrame(ttk.Frame):
         self.set_table_data_from_json(value)
         self.sub_win.destroy()  # close window
 
-    def select_json_file_from_history(self):
+    def select_json_file_from_history(self, _):
+        #:param _: event arg (not used)
         self.sub_win = tk.Toplevel()
         lb = self.Listbox(self.sub_win)
         with open(HISTORY_FILE_PATH) as f:
@@ -305,6 +309,11 @@ def main():
     app.init_search_box()
 
     root.config(menu=menubar)
+    root.bind_all("<Control-o>",app.select_json_file)
+    root.bind_all("<Control-h>",app.select_json_file_from_history)
+    root.bind_all("<Control-e>",app.expand_all)
+    root.bind_all("<Control-l>",app.collapse_all)
+
     root.mainloop()
 
 

--- a/pyjsonviewer/pyjsonviewer.py
+++ b/pyjsonviewer/pyjsonviewer.py
@@ -149,7 +149,7 @@ class JSONTreeFrame(ttk.Frame):
     def find(self, search_text):
         if not search_text:
             return
-        self.collapse_all()
+        self.collapse_all(None)
         for item_id in self.get_all_children(self.tree):
             item_text = self.tree.item(item_id, 'text')
             if search_text.lower() in item_text.lower():


### PR DESCRIPTION
The keyboard shortcuts for the menu didn't seem to work in Windows as well as MacOS.
It only indicated that the keys were pressed but didn't call the function
![noo](https://user-images.githubusercontent.com/55938505/115129299-37b63980-a002-11eb-8bd1-13e36ad496a9.gif)

This problem has been fixed now
![yess](https://user-images.githubusercontent.com/55938505/115129306-4270ce80-a002-11eb-9c6a-0b5988cd56c4.gif)
